### PR TITLE
Fixes and enhancements to support svg markers

### DIFF
--- a/src/Graphics/Svg/Types.hs
+++ b/src/Graphics/Svg/Types.hs
@@ -123,6 +123,7 @@ module Graphics.Svg.Types
 
       -- * Marker definition
     , Marker( .. )
+    , Overflow( .. )
     , MarkerOrientation( .. )
     , MarkerUnit( .. )
     , HasMarker( .. )
@@ -927,6 +928,13 @@ data MarkerUnit
   | MarkerUnitUserSpaceOnUse -- ^ Value `userSpaceOnUse`
   deriving (Eq, Show)
 
+-- | Define the content of the `markerUnits` attribute
+-- on the Marker.
+data Overflow
+  = OverflowVisible    -- ^ Value `visible`
+  | OverflowHidden     -- ^ Value `hidden`
+  deriving (Eq, Show)
+
 -- | Define the `<marker>` tag.
 data Marker = Marker
   { -- | Draw attributes of the marker.
@@ -947,6 +955,8 @@ data Marker = Marker
     -- | Optional viewbox
   , _markerViewBox  :: !(Maybe (Double, Double, Double, Double))
     -- | Elements defining the marker.
+  , _markerOverflow :: !(Maybe Overflow)
+    -- | Elements defining the marker.
   , _markerElements :: [Tree]
   }
   deriving (Eq, Show)
@@ -966,6 +976,7 @@ instance WithDefaultSvg Marker where
     , _markerOrient = Nothing -- MarkerOrientation
     , _markerUnits = Nothing -- MarkerUnitStrokeWidth
     , _markerViewBox = Nothing
+    , _markerOverflow = Nothing
     , _markerElements = mempty
     }
 

--- a/src/Graphics/Svg/XmlParser.hs
+++ b/src/Graphics/Svg/XmlParser.hs
@@ -1047,17 +1047,14 @@ xmlOfDocument doc =
     isElementNotNone (ElementGeometry el) = isNotNone el
     isElementNotNone _ = True
 
-    elementRender k e = case e of
+    elementRender k e = X.add_attr (attr "id" k) $ case e of
         ElementGeometry t -> serializeTreeNode t
         ElementMarker m -> serializeTreeNode m
         ElementMask m -> serializeTreeNode m
         ElementClipPath c -> serializeTreeNode c
-        ElementPattern p ->
-            X.add_attr (attr "id" k) $ serializeTreeNode p
-        ElementLinearGradient lg ->
-            X.add_attr (attr "id" k) $ serializeTreeNode lg
-        ElementRadialGradient rg ->
-            X.add_attr (attr "id" k) $ serializeTreeNode rg
+        ElementPattern p -> serializeTreeNode p
+        ElementLinearGradient lg -> serializeTreeNode lg
+        ElementRadialGradient rg -> serializeTreeNode rg
 
     docViewBox = case _viewBox doc of
         Nothing -> []

--- a/src/Graphics/Svg/XmlParser.hs
+++ b/src/Graphics/Svg/XmlParser.hs
@@ -222,6 +222,16 @@ instance ParseableAttribute MarkerUnit where
     MarkerUnitStrokeWidth -> "strokeWidth"
     MarkerUnitUserSpaceOnUse -> "userSpaceOnUse"
 
+instance ParseableAttribute Overflow where
+  aparse s = case s of
+    "visible" -> Just OverflowVisible
+    "hidden" -> Just OverflowHidden
+    _ -> Nothing
+
+  aserialize u = Just $ case u of
+    OverflowVisible -> "visible"
+    OverflowHidden -> "hidden"
+
 instance ParseableAttribute MarkerOrientation where
   aparse s = case (s, readMaybe s) of
     ("auto", _) -> Just OrientationAuto
@@ -770,6 +780,7 @@ instance XMLUpdatable Marker where
     ,"patternUnits" `parseIn` markerUnits
     ,"orient" `parseIn` markerOrient
     ,"viewBox" `parseIn` markerViewBox
+    ,"overflow" `parseIn` markerOverflow
     ]
 
 serializeText :: Text -> X.Element


### PR DESCRIPTION
- all definitions need to be named (by id attribute)
- markers are invisible unless the overflow attribute is set properly
