### PR TITLE
Fix/number shorthand

### DIFF
--- a/svg-tree.cabal
+++ b/svg-tree.cabal
@@ -38,10 +38,10 @@ library
   exposed-modules: Graphics.Svg
                  , Graphics.Svg.CssTypes
                  , Graphics.Svg.Types
+                 , Graphics.Svg.PathParser
 
   other-modules: Graphics.Svg.NamedColors
                , Graphics.Svg.XmlParser
-               , Graphics.Svg.PathParser
                , Graphics.Svg.CssParser
                , Graphics.Svg.ColorParser
 
@@ -59,3 +59,15 @@ library
                , mtl        >= 2.1 && < 2.3
                , lens       >= 4.6 && < 5
 
+test-suite test
+  hs-source-dirs: test
+  main-is: Spec.hs
+  type: exitcode-stdio-1.0
+  build-depends: base
+               , svg-tree
+               , attoparsec >= 0.12
+               , scientific >= 0.3
+               , linear     >= 1.20
+               , hspec
+  ghc-options: -Wall -threaded
+  other-modules: PathParserSpec

--- a/test/PathParserSpec.hs
+++ b/test/PathParserSpec.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE OverloadedStrings #-}
+module PathParserSpec where
+
+import Data.Attoparsec.Text
+import Graphics.Svg.PathParser
+import Graphics.Svg.Types
+import Linear
+import Test.Hspec
+
+
+spec :: Spec
+spec = do
+  describe "num" $ do
+    it "support shorthand number" $ do
+      parseOnly command d `shouldBe` Right p
+      where
+        d = "M-.10 .10z"
+        p = MoveTo OriginAbsolute [V2 (-0.1) 0.10]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
Hi, I'm working with many SVG files which use shorthand syntax for number, where they write `.456` instead of `0.456`. It is valid by the spec and rendered correctly in all browsers however it is rejected by `svg-tree`. I'm not very familiar with `attoparsec` so please let me know if I can improve the fix/test.

Best regards,

