### PR TITLE
Fix rect defaults

### DIFF
--- a/src/Graphics/Svg/Types.hs
+++ b/src/Graphics/Svg/Types.hs
@@ -314,7 +314,7 @@ data PreserveAspectRatio = PreserveAspectRatio
   deriving (Eq, Show)
 
 instance WithDefaultSvg PreserveAspectRatio where
-  defaultSvg = PreserveAspectRatio 
+  defaultSvg = PreserveAspectRatio
     { _aspectRatioDefer     = False
     , _aspectRatioAlign     = AlignxMidYMid
     , _aspectRatioMeetSlice = Nothing
@@ -2193,7 +2193,7 @@ data Pattern = Pattern
       -- attribute.
     , _patternUnit        :: !CoordinateUnits
       -- | Value of the "preserveAspectRatio" attribute
-    , _patternAspectRatio :: !PreserveAspectRatio 
+    , _patternAspectRatio :: !PreserveAspectRatio
       -- | Value of "patternTransform" attribute
     , _patternTransform   :: !(Maybe [Transformation])
     }
@@ -2486,7 +2486,7 @@ instance CssMatcheable Tree where
 --------------------------------------------------------------------------
 --- Dumped
 --------------------------------------------------------------------------
--- makeClassy ''PreserveAspectRatio 
+-- makeClassy ''PreserveAspectRatio
 --
 -- | Lenses for the PreserveAspectRatio type
 class HasPreserveAspectRatio a where
@@ -2699,4 +2699,3 @@ instance HasDrawAttributes DrawAttributes where
     fmap (\y -> attr { _textAnchor = y }) (f $ _textAnchor attr)
   transform f attr =
     fmap (\y -> attr { _transform = y }) (f $ _transform attr)
-

--- a/src/Graphics/Svg/Types.hs
+++ b/src/Graphics/Svg/Types.hs
@@ -674,14 +674,14 @@ data Rectangle = Rectangle
   , _rectUpperLeftCorner :: !Point
     -- | Rectangle width, correspond, strangely, to
     -- the `width` attribute.
-  , _rectWidth           :: !Number
+  , _rectWidth           :: !(Maybe Number)
     -- | Rectangle height, correspond, amazingly, to
     -- the `height` attribute.
-  , _rectHeight          :: !Number
+  , _rectHeight          :: !(Maybe Number)
     -- | Define the rounded corner radius radius
     -- of the rectangle. Correspond to the `rx` and
     -- `ry` attributes.
-  , _rectCornerRadius    :: !(Number, Number)
+  , _rectCornerRadius    :: !(Maybe Number, Maybe Number)
   }
   deriving (Eq, Show)
 
@@ -689,7 +689,7 @@ data Rectangle = Rectangle
 -- | Lenses for the Rectangle type.
 class HasRectangle a where
   rectangle :: Lens' a Rectangle
-  rectCornerRadius :: Lens' a (Number, Number)
+  rectCornerRadius :: Lens' a (Maybe Number, Maybe Number)
   {-# INLINE rectCornerRadius #-}
   rectCornerRadius = rectangle . rectCornerRadius
 
@@ -697,7 +697,7 @@ class HasRectangle a where
   {-# INLINE rectDrawAttributes #-}
   rectDrawAttributes = rectangle . rectDrawAttributes
 
-  rectHeight :: Lens' a Number
+  rectHeight :: Lens' a (Maybe Number)
   {-# INLINE rectHeight #-}
   rectHeight = rectangle . rectHeight
 
@@ -705,7 +705,7 @@ class HasRectangle a where
   {-# INLINE rectUpperLeftCorner #-}
   rectUpperLeftCorner = rectangle . rectUpperLeftCorner
 
-  rectWidth :: Lens' a Number
+  rectWidth :: Lens' a (Maybe Number)
   {-# INLINE rectWidth #-}
   rectWidth = rectangle . rectWidth
 
@@ -734,9 +734,9 @@ instance WithDefaultSvg Rectangle where
   defaultSvg = Rectangle
     { _rectDrawAttributes  = mempty
     , _rectUpperLeftCorner = (Num 0, Num 0)
-    , _rectWidth           = Num 0
-    , _rectHeight          = Num 0
-    , _rectCornerRadius    = (Num 0, Num 0)
+    , _rectWidth           = Nothing
+    , _rectHeight          = Nothing
+    , _rectCornerRadius    = (Nothing, Nothing)
     }
 
 -- | Type mapping the `<path>` svg tag.


### PR DESCRIPTION
Width, height, rx and ry should default to 'auto' rather than '0'. It happens often that 'auto' computes to '0' but it's not always the case.

This PR contains breaking API changes.