### PR TITLE
Fix element trees

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 v0.6.2.3 October 2018
 
  * GHC 8.6 fixes
+ * Adding: Allow definitions to appear anywhere in an svg document.
 
 v0.6.2.2 December 2017
 

--- a/src/Graphics/Svg.hs
+++ b/src/Graphics/Svg.hs
@@ -91,22 +91,10 @@ resolveUses doc =
     fetchUses (UseTree useInfo _) = UseTree useInfo $ search useInfo
     fetchUses a = a
 
-    search nfo = maybe Nothing geometryExtract found where
-      found = M.lookup (_useName nfo) $ _definitions doc
-
-    geometryExtract c = case c of
-      ElementLinearGradient _ -> Nothing
-      ElementRadialGradient _ -> Nothing
-      ElementMeshGradient _ -> Nothing
-      ElementMask _ -> Nothing
-      ElementClipPath _ -> Nothing
-      ElementGeometry t -> Just t
-      ElementPattern _ -> Nothing
-      ElementMarker _ -> Nothing
+    search nfo = M.lookup (_useName nfo) $ _definitions doc
 
 -- | Rewrite the document by applying the CSS rules embedded
 -- inside it.
 applyCSSRules :: Document -> Document
 applyCSSRules doc = doc
     { _elements = cssApply (_styleRules doc) <$> _elements doc }
-

--- a/src/Graphics/Svg/Types.hs
+++ b/src/Graphics/Svg/Types.hs
@@ -1802,10 +1802,10 @@ foldTree f = go where
     LinearGradientTree _ -> f acc e
     RadialGradientTree _ -> f acc e
     MeshGradientTree _ -> f acc e
-    PatternTree _ -> f acc e
-    MarkerTree _ -> f acc e
-    MaskTree _ -> f acc e
-    ClipPathTree _ -> f acc e
+    PatternTree _   -> f acc e
+    MarkerTree _    -> f acc e
+    MaskTree _      -> f acc e
+    ClipPathTree _  -> f acc e
     DefinitionTree d ->
       let subAcc =
             F.foldl' go acc . _groupChildren $ _groupOfDefinitions d in
@@ -1871,9 +1871,9 @@ nameOfTree v =
    RadialGradientTree _ -> "radialgradient"
    MeshGradientTree _ -> "meshgradient"
    PatternTree _   -> "pattern"
-   MarkerTree _   -> "marker"
-   MaskTree _   -> "mask"
-   ClipPathTree _   -> "clipPath"
+   MarkerTree _    -> "marker"
+   MaskTree _      -> "mask"
+   ClipPathTree _  -> "clipPath"
 
 drawAttrOfTree :: Tree -> DrawAttributes
 drawAttrOfTree v = case v of


### PR DESCRIPTION
This PR removes the 'Element' data-type and instead has non-drawable nodes embedded directly in the SVG tree. The primary benefit is that you can create any image as a Tree rather than having to generate a Document.