### PR TITLE
Fix parsing shorthand arc

### DIFF
--- a/src/Graphics/Svg/PathParser.hs
+++ b/src/Graphics/Svg/PathParser.hs
@@ -50,6 +50,11 @@ num = realToFrac <$> (skipSpace *> plusMinus <* skipSpace)
         shorthand = process' <$> (string "." *> many1 digit)
         process' = either (const 0) id . parseOnly doubleNumber . T.pack . (++) "0."
 
+bool :: Parser Bool
+bool = ("1" ==) <$> (skipSpace *> zeroOrOne <* skipSpace)
+  where zeroOrOne = string "0" <|> string "1"
+
+
 viewBoxParser :: Parser (Double, Double, Double, Double)
 viewBoxParser = (,,,)
        <$> iParse <*> iParse <*> iParse <*> iParse
@@ -102,11 +107,12 @@ command =  (MoveTo OriginAbsolute <$ string "M" <*> pointList)
           manyComma a = a `sepBy1` commaWsp
 
           numComma = num <* commaWsp
+          boolComma = bool <* commaWsp
           ellipticalArgs = (,,,,,) <$> numComma
                                    <*> numComma
                                    <*> numComma
-                                   <*> (fmap (/= 0) numComma)
-                                   <*> (fmap (/= 0) numComma)
+                                   <*> boolComma
+                                   <*> boolComma
                                    <*> point
 
 serializePoint :: RPoint -> String

--- a/svg-tree.cabal
+++ b/svg-tree.cabal
@@ -1,5 +1,5 @@
 name:                svg-tree
-version:             0.6.2.4
+version:             0.6.2.4.999
 synopsis:            SVG file loader and serializer
 description:
   svg-tree provides types representing a SVG document,

--- a/test/PathParserSpec.hs
+++ b/test/PathParserSpec.hs
@@ -10,9 +10,20 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
-  describe "num" $ do
+  describe "num" $
     it "support shorthand number" $ do
-      parseOnly command d `shouldBe` Right p
-      where
+      let
         d = "M-.10 .10z"
         p = MoveTo OriginAbsolute [V2 (-0.1) 0.10]
+      parseOnly command d `shouldBe` Right p
+  describe "arc" $ do
+    it "support arc" $ do
+      let
+        d = "a.5 .5 .5 0 0 -.5 .5"
+        p = EllipticalArc OriginRelative [(0.5, 0.5, 0.5, False, False, V2 (-0.5) 0.5)]
+      parseOnly command d `shouldBe` Right p
+    it "support shorthand arc" $ do
+      let
+        d = "a.5 .5 .5 00-.5 .5"
+        p = EllipticalArc OriginRelative [(0.5, 0.5, 0.5, False, False, V2 (-0.5) 0.5)]
+      parseOnly command d `shouldBe` Right p


### PR DESCRIPTION
Shorthand arc (`a5 5 5 005 5`) notation is generated by svgo and commonly seen.  (Not sure about the specification.)