### PR TITLE
Better encoding, `currentColor` support and identifier escaping

### DIFF
--- a/src/Graphics/Svg.hs
+++ b/src/Graphics/Svg.hs
@@ -26,6 +26,7 @@ import qualified Data.ByteString as B
 import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import Text.XML.Light.Lexer ( XmlSource )
 import Text.XML.Light.Input( parseXMLDoc )
 import Text.XML.Light.Output( ppcTopElement, prettyConfigPP )
 import Control.Lens
@@ -38,15 +39,17 @@ import Graphics.Svg.XmlParser
 {-import Graphics.Svg.CssParser-}
 
 -- | Try to load an svg file on disc and parse it as
--- a SVG Document.
+-- a SVG Document using UTF-8 encoding.
 loadSvgFile :: FilePath -> IO (Maybe Document)
 loadSvgFile filename =
-  parseSvgFile filename <$> B.readFile filename
+  parseSvgFile filename . T.decodeUtf8 <$> B.readFile filename
 
--- | Parse an in-memory SVG file
-parseSvgFile :: FilePath    -- ^ Source path/URL of the document, used
+-- | Parse an in-memory SVG file.
+-- Note: Using `B.ByteString` can cause issues with multibyte characters.
+parseSvgFile :: XmlSource s
+             => FilePath    -- ^ Source path/URL of the document, used
                             -- to resolve relative links.
-             -> B.ByteString
+             -> s
              -> Maybe Document
 parseSvgFile filename fileContent =
   parseXMLDoc fileContent >>= unparseDocument filename

--- a/src/Graphics/Svg/ColorParser.hs
+++ b/src/Graphics/Svg/ColorParser.hs
@@ -95,6 +95,7 @@ textureSerializer :: Texture -> String
 textureSerializer (ColorRef px) = colorSerializer px
 textureSerializer (TextureRef str) = printf "url(#%s)" str
 textureSerializer FillNone = "none"
+textureSerializer FillCurrent = "currentColor"
 
 urlRef :: Parser String
 urlRef = string "url(" *> skipSpace *>
@@ -104,8 +105,10 @@ urlRef = string "url(" *> skipSpace *>
 
 textureParser :: Parser Texture
 textureParser =
-  none <|> (TextureRef <$> urlRef)
+  none <|> current
+       <|> (TextureRef <$> urlRef)
        <|> (ColorRef <$> colorParser)
   where
     none = FillNone <$ string "none"
+    current = FillCurrent <$ string "currentColor"
 

--- a/src/Graphics/Svg/PathParser.hs
+++ b/src/Graphics/Svg/PathParser.hs
@@ -102,11 +102,12 @@ command =  (MoveTo OriginAbsolute <$ string "M" <*> pointList)
           manyComma a = a `sepBy1` commaWsp
 
           numComma = num <* commaWsp
+          flagComma = ((True <$ char '1' <|> False <$ char '0') <* commaWsp)
           ellipticalArgs = (,,,,,) <$> numComma
                                    <*> numComma
                                    <*> numComma
-                                   <*> (fmap (/= 0) numComma)
-                                   <*> (fmap (/= 0) numComma)
+                                   <*> flagComma
+                                   <*> flagComma
                                    <*> point
 
 serializePoint :: RPoint -> String

--- a/src/Graphics/Svg/Types.hs
+++ b/src/Graphics/Svg/Types.hs
@@ -189,7 +189,6 @@ import Data.Foldable( Foldable )
 import Data.Function( on )
 import Data.List( inits )
 import qualified Data.Map as M
-import Data.Semigroup( Semigroup( .. ) )
 import Data.Monoid( Last( .. ) )
 import qualified Data.Foldable as F
 import qualified Data.Text as T
@@ -314,7 +313,7 @@ data PreserveAspectRatio = PreserveAspectRatio
   deriving (Eq, Show)
 
 instance WithDefaultSvg PreserveAspectRatio where
-  defaultSvg = PreserveAspectRatio 
+  defaultSvg = PreserveAspectRatio
     { _aspectRatioDefer     = False
     , _aspectRatioAlign     = AlignxMidYMid
     , _aspectRatioMeetSlice = Nothing
@@ -345,6 +344,7 @@ data Texture
   = ColorRef   PixelRGBA8 -- ^ Direct solid color (#rrggbb, #rgb)
   | TextureRef String     -- ^ Link to a complex texture (url(#name))
   | FillNone              -- ^ Equivalent to the `none` value.
+  | FillCurrent           -- ^ Equivalent to the `currentColor` value.
   deriving (Eq, Show)
 
 -- | Describe the possile filling algorithms.
@@ -2193,7 +2193,7 @@ data Pattern = Pattern
       -- attribute.
     , _patternUnit        :: !CoordinateUnits
       -- | Value of the "preserveAspectRatio" attribute
-    , _patternAspectRatio :: !PreserveAspectRatio 
+    , _patternAspectRatio :: !PreserveAspectRatio
       -- | Value of "patternTransform" attribute
     , _patternTransform   :: !(Maybe [Transformation])
     }
@@ -2486,7 +2486,7 @@ instance CssMatcheable Tree where
 --------------------------------------------------------------------------
 --- Dumped
 --------------------------------------------------------------------------
--- makeClassy ''PreserveAspectRatio 
+-- makeClassy ''PreserveAspectRatio
 --
 -- | Lenses for the PreserveAspectRatio type
 class HasPreserveAspectRatio a where

--- a/src/Graphics/Svg/XmlParser.hs
+++ b/src/Graphics/Svg/XmlParser.hs
@@ -29,7 +29,7 @@ import Control.Applicative( (<|>), many )
 import Control.Lens hiding( transform, children, elements, element )
 import Control.Monad.State.Strict( State, runState, modify, gets )
 import Data.Maybe( fromMaybe, catMaybes )
-import Data.Monoid( Last( Last ), getLast, (<>) )
+import Data.Monoid( Last( Last ), getLast )
 import Data.List( foldl', intercalate )
 import Text.XML.Light.Proc( findAttrBy, elChildren, strContent )
 import qualified Text.XML.Light as X
@@ -128,7 +128,7 @@ instance ParseableAttribute [Transformation] where
 
 instance ParseableAttribute Alignment where
   aparse s = Just $ case s of
-    "none" -> AlignNone 
+    "none" -> AlignNone
     "xMinYMin" -> AlignxMinYMin
     "xMidYMin" -> AlignxMidYMin
     "xMaxYMin" -> AlignxMaxYMin
@@ -141,7 +141,7 @@ instance ParseableAttribute Alignment where
     _ -> _aspectRatioAlign defaultSvg
 
   aserialize v = Just $ case v of
-    AlignNone -> "none" 
+    AlignNone -> "none"
     AlignxMinYMin -> "xMinYMin"
     AlignxMidYMin -> "xMidYMin"
     AlignxMaxYMin -> "xMaxYMin"
@@ -157,7 +157,7 @@ instance ParseableAttribute MeshGradientType where
     "bilinear" -> GradientBilinear
     "bicubic" -> GradientBicubic
     _ -> GradientBilinear
-  
+
   aserialize v = Just $ case v of
     GradientBilinear -> "bilinear"
     GradientBicubic -> "bicubic"
@@ -192,7 +192,7 @@ instance ParseableAttribute PreserveAspectRatio where
             , _aspectRatioAlign = alignOf align
             }
       ["defer", align, meet] ->
-          Just $ PreserveAspectRatio 
+          Just $ PreserveAspectRatio
               { _aspectRatioDefer = True
               , _aspectRatioAlign = alignOf align
               , _aspectRatioMeetSlice = aparse meet
@@ -523,6 +523,7 @@ cssUniqueTexture :: ASetter el el
                  -> CssUpdater el
 cssUniqueTexture setter attr css = case css of
   ((CssIdent "none":_):_) -> attr & setter .~ Last (Just FillNone)
+  ((CssIdent "currentColor":_):_) -> attr & setter .~ Last (Just FillCurrent)
   ((CssColor c:_):_) -> attr & setter .~ Last (Just $ ColorRef c)
   ((CssFunction "url" [CssReference c]:_):_) ->
         attr & setter .~ Last (Just . TextureRef $ T.unpack c)
@@ -908,7 +909,7 @@ serializeText topText = namedNode where
     (Nothing, Nothing) -> Nothing
     (Just a, Nothing) -> Just $ setChildren a subContent
     (Nothing, Just b) -> Just $ setChildren b subContent
-    (Just a, Just b) -> 
+    (Just a, Just b) ->
         Just $ setChildren (mergeAttributes a b) subContent
     where
       info = genericSerializeNode $ _spanInfo tspan
@@ -1004,7 +1005,7 @@ instance XMLUpdatable GradientStop where
           [(opacitySetter "stop-opacity" gradientOpacity, (cssUniqueFloat gradientOpacity))
           ,("stop-color" `parseIn` gradientColor, cssUniqueColor gradientColor)
           ]
-      
+
       lst =
         [gradientOffsetSetter
         ,"path" `parseIn` gradientPath

--- a/test/PathParserSpec.hs
+++ b/test/PathParserSpec.hs
@@ -11,8 +11,15 @@ import Test.Hspec
 spec :: Spec
 spec = do
   describe "num" $ do
+    let d = "M-.10 .10z"
+        p = MoveTo OriginAbsolute [V2 (-0.1) 0.10]
     it "support shorthand number" $ do
       parseOnly command d `shouldBe` Right p
-      where
-        d = "M-.10 .10z"
-        p = MoveTo OriginAbsolute [V2 (-0.1) 0.10]
+  describe "arc" $ do
+    let d = "a1.3 1.3 0 01-1.3-1.3"
+    --                  ^^ Those two numbers are 2 flags.
+    -- This is valid SVG sequence according to https://www.w3.org/TR/SVG/paths.html#PathDataBNF
+    -- as flag can be only "0" or "1" and separator is optional.
+        p = EllipticalArc OriginRelative [(1.3, 1.3, 0, False, True, V2 (-1.3) (-1.3))]
+    it "support flags without separators" $ do
+      parseOnly command d `shouldBe` Right p


### PR DESCRIPTION
This is batch of changes that was necessary for my SVG sprite tool.

 - `currentColor` support:
   - I wanted sprite to be able to change color by external `color` attribute. (https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color)
 - Identifier escaping
   - I wanted to use `.` character as part of identifier. This is perfectly valid in HTML/XML. As such, CSS supports such identifier as well, the special character just have to be escaped.
 -  Unicode encoding
    - Default "encoding-less" `ByteString` approach doesn't work properly (loading and storing) when SVG contains some multi-byte characters. This specifically applies to CSS escaping for identifiers, which would escape the multi-byte characters as separate characters instead of single one when `ByteString` is used instead of `String` or `Text`.
 - Flag parsing in path's `arc`
   - Some SVG optimizers can produce output like this `a1.3 1.3 0 01-1.3-1.3` (yes, it's valid). You can see `01` in the output which no a single number, but two flags. Current path parser failed on such path segment.