### PR TITLE
Allow mtl-2.3 and transformers-0.6

### DIFF
--- a/svg-tree.cabal
+++ b/svg-tree.cabal
@@ -61,8 +61,8 @@ library
                , linear     >= 1.20
                , vector     >= 0.10
                , text       >= 1.1
-               , transformers >= 0.3 && < 0.6
-               , mtl        >= 2.1 && < 2.3
+               , transformers >= 0.3 && < 0.7
+               , mtl        >= 2.1 && < 2.4
                , lens       >= 4.6
 
 test-suite test


### PR DESCRIPTION
Required to build with GHC 9.6.

As a Hackage trustee I made a matching revision:
https://hackage.haskell.org/package/svg-tree-0.6.2.4/revisions/